### PR TITLE
Fix building on Raspbian 2020-02-13 (issues #1 and #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run [PXT](https://github.com/microsoft/pxt) from your pi!
 
 ## install.sh
 
-Installs the Node.js v0.6.x, the PXT command line
+Installs Node.js v10.x, the PXT command line
 and sets up the microbit target.
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@
 ###################################
 # install latest node.js
 
-curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
-sudo apt-get install -y build-essential nodejs
+curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+sudo apt-get install -y build-essential nodejs libudev-dev
 # install PXT
 sudo npm install -g pxt
 # setup microbit


### PR DESCRIPTION
These commits update the script to download Node.js 10.x and to install `libudev-dev`, as required for building from source.

Relevant issues are #1 and #2.